### PR TITLE
Updating index page with journey details

### DIFF
--- a/data/base.yaml
+++ b/data/base.yaml
@@ -3,10 +3,11 @@ site_description: Ansible Documentation
 site_author: Ansible Community
 ansible_version: 7
 pages:
+  user: user.html
+  developer: developer.html
+  maintainer: maintainer.html
   collections: collections.html
   community: community.html
   core: core.html
-  developer: developer.html
   ecosystem: ecosystem.html
   index: index.html
-  user: user.html

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -9,7 +9,7 @@ index:
     action_two: Set up an Ansible automation project
     action_three: Write your first playbook in a few easy steps
   #Ansible user
-  user_persona_heading: Ansible users
+  user_heading: Ansible users
   user_base_body: Ansible playbooks are blueprints for automating software deployment and system configuration as well as orchestrating complex operations.
   user_base_actions:
     #Labels provide meaningful descriptions of elements for accessibility purposes.
@@ -19,13 +19,28 @@ index:
     action_three: Build inventory files to manage multiple hosts
   user_resources_heading: User resources
   user_resources_body: Structure your project with roles, improve content quality, re-use existing automation, and more.
-  user_resources_action: Unleash your automation
+  user_resources_action: Find user resources
   #Ansible developer
-  dev_main_heading:
-  dev_body:
-  dev_secondary_heading:
-  dev_secondary_body:
-  dev_button:
-    button_one:
-    button_two:
-    button_three:
+  developer_heading: Ansible developers
+  developer_base_body: Ansible is open-source. You can add code that fixes bugs, implements new features, or extends the benefits of simple, agentless automation.
+  developer_base_actions:
+    #Labels provide meaningful descriptions of elements for accessibility purposes.
+    action_label: Button group that links to base Ansible developer documentation.
+    action_one: Set up your development environment
+    action_two: Review the Ansible contributor guidelines
+    action_three: Write custom modules or plugins
+  developer_resources_heading: Developer resources
+  developer_resources_body: Contribute to an Ansible project or collection, run sanity tests, write integration and unit tests, and more.
+  developer_resources_action: Find developer resources
+  #Community maintainer
+  maintainer_heading: Community maintainers
+  maintainer_base_body: Ansible maintainers are responsible for the ongoing quality of collections and play a vital role in guiding the direction of the wider community.
+  maintainer_base_actions:
+    #Labels provide meaningful descriptions of elements for accessibility purposes.
+    action_label: Button group that links to base Ansible community maintainer documentation.
+    action_one: Learn about the Ansible community
+    action_two: Review and agree to the code of conduct
+    action_three: Join or start a discussion that interests you
+  maintainer_resources_heading: Community maintainer resources
+  maintainer_resources_body: Handle project lifecycles, ensure the health of collections, join the Ansible steering committe, and more.
+  maintainer_resources_action: Find maintainer resources

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -44,5 +44,5 @@ index:
     action_two: Review and agree to the code of conduct
     action_three: Join or start a discussion that interests you
   maintainer_resources_heading: Community maintainer resources
-  maintainer_resources_body: Handle project lifecycles, ensure the health of collections, join the Ansible steering committe, and more.
+  maintainer_resources_body: Handle project lifecycles, ensure the health of collections, join the Ansible steering committee, and more.
   maintainer_resources_action: Find maintainer resources

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -24,7 +24,7 @@ index:
   user_resources_action: Find user resources
   #Ansible developer
   developer_heading: Ansible developers
-  developer_base_body: Ansible is open-source. You can add code that fixes bugs, implements new features, or extends the benefits of simple, agentless automation.
+  developer_base_body: Ansible is open source. You can add code that fixes bugs, implements new features, or extends the benefits of simple, agentless automation.
   developer_base_actions:
     #Labels provide meaningful descriptions of elements for accessibility purposes.
     action_label: Button group that links to base Ansible developer documentation.

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -8,6 +8,8 @@ index:
     action_one: Understand the fundamentals of Ansible automation
     action_two: Set up an Ansible automation project
     action_three: Write your first playbook in a few easy steps
+  #Ansible installation
+  install_action: Go to the installation guide
   #Ansible user
   user_heading: Ansible users
   user_base_body: Ansible playbooks are blueprints for automating software deployment and system configuration as well as orchestrating complex operations.

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -36,7 +36,7 @@ index:
   developer_resources_action: Find developer resources
   #Community maintainer
   maintainer_heading: Community maintainers
-  maintainer_base_body: Ansible maintainers are responsible for the ongoing quality of collections and play a vital role in guiding the direction of the wider community.
+  maintainer_base_body: Ansible maintainers are responsible for the ongoing quality of  Ansible projects and collections and play a vital role in guiding the direction of the wider community.
   maintainer_base_actions:
     #Labels provide meaningful descriptions of elements for accessibility purposes.
     action_label: Button group that links to base Ansible community maintainer documentation.

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,7 @@
       <div class="card-body">
         <h4>{{ pages.index.welcome }}</h4>
         <p class="card-text">{{ pages.index.about_ansible }}</p>
+        <!--Start novice section-->
         <div class="btn-group-vertical" role="group" aria-label="{{ pages.index.novice_actions.action_label }}">
             <a class="btn btn-primary" href="{{ links.core_docs.index }}" role="button">{{ pages.index.novice_actions.action_one }}</a>
             <a class="btn btn-primary" href="{{ links.core_docs.start }}" role="button">{{ pages.index.novice_actions.action_two }}</a>
@@ -24,11 +25,11 @@
       </div>
     </div>
   </div>
-  <!--Start Ansible user section-->
+  <!--Start user section-->
   <div class="row justify-content-center">
     <div class="w-50 p-0">
       <div class="card-body">
-        <h5>{{ pages.index.user_persona_heading }} <i class="fas fa-cogs"></i></h5>
+        <h5>{{ pages.index.user_heading }} <i class="fas fa-cogs"></i></h5>
         <p class="card-text">{{ pages.index.user_base_body }}</p>
         <div class="btn-group-vertical" role="group" aria-label="{{ pages.index.user_base_actions.action_label }}">
             <a class="btn btn-primary" href="{{ links.core_docs.inventory_guide }}" role="button">{{ pages.index.user_base_actions.action_one }}</a>
@@ -45,84 +46,45 @@
       </div>
     </div>
   </div>
-  <!--Start developers cards-->
+  <!--Start developer section-->
   <div class="row justify-content-center">
     <div class="w-50 p-0">
       <div class="card-body">
-        <h5>Developers <i class="fas fa-code"></i></h5>
-        <p class="card-text">
-          Add Ansible functionality with plugins and modules. Lorem ipsum text
-          to replace with abstract that matches persona high-level goals.
-        </p>
-        <div class="btn-group-vertical" role="group" aria-label="Developer group">
-            <a class="btn btn-primary" href="{{ links.dev_docs.ansible_architecture }}" role="button">Learn Ansible architecture</a>
-            <a class="btn btn-primary" href="{{ links.dev_docs.environment_setup }}" role="button">Set up a Python environment</a>
-            <a class="btn btn-primary" href="{{ links.dev_docs.developing_modules }}" role="button">Start coding plugins</a>
+        <h5>{{ pages.index.developer_heading }} <i class="fas fa-code"></i></h5>
+        <p class="card-text">{{ pages.index.developer_base_body }}</p>
+        <div class="btn-group-vertical" role="group" aria-label="{{ pages.index.developer_base_actions.action_label }}">
+            <a class="btn btn-primary" href="{{ links.dev_docs.ansible_architecture }}" role="button">{{ pages.index.developer_base_actions.action_one }}</a>
+            <a class="btn btn-primary" href="{{ links.dev_docs.environment_setup }}" role="button">{{ pages.index.developer_base_actions.action_two }}</a>
+            <a class="btn btn-primary" href="{{ links.dev_docs.developing_modules }}" role="button">{{ pages.index.developer_base_actions.action_three }}</a>
         </div>
       </div>
     </div>
     <div class="w-25 p-0">
       <div class="card-body">
-        <h5>Developer resources</h5>
-        <p class="card-text">
-          Lorem ipsum text to replace with high-level overview of the Ansible
-          developer resources.
-        </p>
-        <a class="btn btn-primary" href="{{ base.pages.developer }}" role="button">Explore Ansible projects</a>
+        <h5>{{ pages.index.developer_resources_heading }}</h5>
+        <p class="card-text">{{ pages.index.user_resources_body }}</p>
+        <a class="btn btn-primary" href="{{ base.pages.developer }}" role="button">{{ pages.index.developer_resources_action }}</a>
       </div>
     </div>
   </div>
-  <!--Start community maintainer cards-->
+  <!--Start community maintainer section-->
   <div class="row justify-content-center">
     <div class="w-50 p-0">
       <div class="card-body">
-        <h5>Collections <i class="fas fa-project-diagram"></i></h5>
-        <p class="card-text">
-          Extend automation with Ansible collections. Lorem ipsum text to
-          replace with abstract that matches persona high-level goals.
-        </p>
-        <div class="btn-group-vertical" role="group" aria-label="Collections group">
-          <a class="btn btn-primary" href="https://docs.ansible.com/ansible/latest/inventory_guide/index.html" role="button">Finding and using Ansible collections</a>
-          <a class="btn btn-primary" href="https://docs.ansible.com/ansible/latest/playbook_guide/index.html" role="button">Contributing to collections</a>
-          <a class="btn btn-primary" href="https://docs.ansible.com/ansible/latest/collections/all_plugins.html" role="button">Maintaining collections</a>
+        <h5>{{ pages.index.maintainer_heading }} <i class="fas fa-project-diagram"></i></h5>
+        <p class="card-text">{{ pages.index.maintainer_base_body }}</p>
+        <div class="btn-group-vertical" role="group" aria-label="{{ pages.index.maintainer_base_actions.action_label }}">
+          <a class="btn btn-primary" href="https://docs.ansible.com/ansible/latest/inventory_guide/index.html" role="button">{{ pages.index.maintainer_base_actions.action_one }}</a>
+          <a class="btn btn-primary" href="https://docs.ansible.com/ansible/latest/playbook_guide/index.html" role="button">{{ pages.index.maintainer_base_actions.action_two }}</a>
+          <a class="btn btn-primary" href="https://docs.ansible.com/ansible/latest/collections/all_plugins.html" role="button">{{ pages.index.maintainer_base_actions.action_three }}</a>
         </div>
       </div>
     </div>
     <div class="w-25 p-0">
       <div class="card-body">
-        <h5>Collections resources</h5>
-        <p class="card-text">
-          Lorem ipsum text to replace with high-level overview of the Ansible
-          collections resources.
-        </p>
-        <a class="btn btn-primary" href="{{ base.pages.collections }}" role="button">Explore Ansible projects</a>
-      </div>
-    </div>
-  </div>
-  <!--Start community cards-->
-  <div class="row justify-content-center">
-    <div class="w-50 p-0">
-      <div class="card-body">
-        <h5>Community <i class="fas fa-users"></i></h5>
-        <p class="card-text">
-          Join the Ansible community with this call to action. Lorem ipsum text to
-          replace with abstract that matches persona high-level goals.
-        </p>
-        <div class="btn-group-vertical" role="group" aria-label="Community group">
-          <a class="btn btn-primary" href="https://docs.ansible.com/ansible/latest/inventory_guide/index.html" role="button">Finding and using Ansible collections</a>
-          <a class="btn btn-primary" href="https://docs.ansible.com/ansible/latest/playbook_guide/index.html" role="button">Contributing to collections</a>
-          <a class="btn btn-primary" href="https://docs.ansible.com/ansible/latest/collections/all_plugins.html" role="button">Maintaining collections</a>
-        </div>
-      </div>
-    </div>
-    <div class="w-25 p-0">
-      <div class="card-body">
-        <h5>Ansible community resources</h5>
-        <p class="card-text">
-          Lorem ipsum text to replace with high-level overview of the Ansible
-          community resources.
-        </p>
-        <a class="btn btn-primary" href="{{ base.pages.community }}" role="button">Join the Ansible community</a>
+        <h5>{{ pages.index.maintainer_resources_heading }}</h5>
+        <p class="card-text">{{ pages.index.maintainer_resources_body }}</p>
+        <a class="btn btn-primary" href="{{ base.pages.maintainer }}" role="button">{{ pages.index.maintainer_resources_action }}</a>
       </div>
     </div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,6 +22,7 @@
         <div class="clipboard">
           <pre><code id="clip">pip install ansible</code><button class="btn" data-clipboard-action="copy" data-clipboard-target="#clip"> <i class='far fa-clipboard'></i></button></pre>
         </div>
+        <a class="btn btn-primary" href="{{ links.core_docs.install }}" role="button">{{ pages.index.install_action }}</a>
       </div>
     </div>
   </div>

--- a/templates/maintainer.html
+++ b/templates/maintainer.html
@@ -1,0 +1,4 @@
+{% extends "_base.html" %}
+{% block body %}
+<p>Community maintainer resources go here.</p>
+{% endblock %}


### PR DESCRIPTION
This PR takes details from the journey maps here: https://github.com/ansible/docsite/blob/personas/user-journeys/ansible-user-journey-maps.md

And adds those details to the index page. Note that we decided to remove the section for basic community member from the index page. We'll have a general "Join the community" page for those details.