### PR TITLE
Improve developer pages and layout

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -16,11 +16,6 @@ user_actions:
   automate: "https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_intro.html#playbook-syntax"
   evaluate_plugins: "https://docs.ansible.com/ansible/latest/module_plugin_guide/modules_intro.html"
   build_inventory: "https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html"
-developer_actions:
-  setup: "https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#environment-setup"
-  guidelines: "https://docs.ansible.com/ansible/latest/community/getting_started.html"
-  start: "https://docs.ansible.com/ansible/latest/dev_guide/developing_locally.html"
-  learn: "https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html"
 maintainer_actions:
   overview: "https://docs.ansible.com/ansible/latest/community/contributor_path.html"
   learn: "https://docs.ansible.com/ansible/latest/community/maintainers_guidelines.html"
@@ -47,9 +42,10 @@ project_doc_home:
   vscode: "https://marketplace.visualstudio.com/items?itemName=redhat.ansible"
 developer:
   start:
-    overview: "https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html"
-    setup: "https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#preparing-an-environment-for-developing-ansible-modules"
+    setup: "https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#environment-setup"
     conduct: "https://docs.ansible.com/ansible/latest/community/code_of_conduct.html"
+    learn: "https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html"
+    code: "https://docs.ansible.com/ansible/latest/dev_guide/developing_locally.html"
   contribute:
     checklist: "https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_checklist.html"
     lifecycle: "https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html"

--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -40,12 +40,6 @@ index:
   # Ansible developer
   developer_heading: Ansible developers
   developer_body: Ansible is open source. You can add code that fixes bugs, implements new features, or extends the benefits of simple, agentless automation.
-  developer_actions:
-    # Labels provide meaningful descriptions of elements for accessibility purposes.
-    label: Button group that links to base Ansible developer documentation.
-    setup: Set up your development environment
-    guidelines: Review the Ansible contributor guidelines
-    start: Write custom modules or plugins
   developer_resources_heading: Developer resources
   developer_resources_body: Contribute to an Ansible project or collection, run sanity tests, write integration and unit tests, and more.
   developer_resources_action: Find more resources for developing with Ansible
@@ -75,11 +69,12 @@ developer:
     test: Test plugins and modules
     create_collection: Create new collections
   start:
-    intro: Ready to start writing code for Ansible? Follow these steps to get started.
     label: Button group that links to starting developer documentation.
-    overview: Understand the Ansible architecture
+    intro: Ready to start writing code for Ansible? Follow these steps to get started.
     setup: Set up your development environment
-    conduct: Review code of conduct and contributor guidelines
+    conduct: Review the Ansible contributor guidelines
+    learn: Understand the Ansible architecture
+    code: Write custom modules or plugins
   contribute:
     intro: Contribute your code to an Ansible project or collection.
     label: Button group that links to developer contribution documentation.

--- a/templates/developer.html
+++ b/templates/developer.html
@@ -1,49 +1,52 @@
-{% extends "_base.html" %}
-{% block body %}
+{% extends "_base.html" %} {% block body %}
 <div class="container">
-    <div class="page-title">
-      <h2>{{ pages.developer.title }}</h2>
-      <p>{{ pages.developer.intro }}</p>
-    </div>
-    <div class="full-width-bg component">
-      <div class="grid-wrapper">
-        <div class="width-6-12 width-12-12-m">
-          <h3>{{ pages.developer.milestone.start }}</h3>
-          <p>{{ pages.developer.start.intro }}</p>
-          <div class="btn-group-vertical" role="group" aria-label="{{ pages.developer.start.label }}">
-            <a class="btn btn-primary" href="{{ links.developer.start.setup }}" role="button">{{ pages.developer.start.setup }}</a>
-            <a class="btn btn-primary" href="{{ links.developer.start.conduct }}" role="button">{{ pages.developer.start.conduct }}</a>
-          </div>
+  <div class="page-title">
+    <h2>{{ pages.developer.title }}</h2>
+    <p>{{ pages.developer.intro }}</p>
+  </div>
+  <div class="full-width-bg component">
+    <div class="grid-wrapper">
+      <div class="width-6-12 width-12-12-m">
+        <h3>{{ pages.developer.milestone.start }}</h3>
+        <p>{{ pages.developer.start.intro }}</p>
+        <div class="btn-group-vertical" role="group" aria-label="{{ pages.developer.start.label }}">
+          <a class="btn btn-primary" href="{{ links.developer.start.setup }}" role="button">{{ pages.developer.start.setup }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.start.conduct }}" role="button">{{ pages.developer.start.conduct }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.start.learn }}" role="button">{{ pages.developer.start.learn }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.start.code }}" role="button">{{ pages.developer.start.code }}</a>
         </div>
-        <div class="width-6-12 width-12-12-m">
-          <h3>{{ pages.developer.milestone.contribute }}</h3>
-          <p>{{ pages.developer.contribute.intro }}</p>
-          <div class="btn-group-vertical" role="group" aria-label="{{ pages.developer.contribute.label }}">
-            <a class="btn btn-primary" href="{{ links.developer.contribute.checklist }}" role="button">{{ pages.developer.contribute.checklist }}</a>
-            <a class="btn btn-primary" href="{{ links.developer.contribute.lifecycle }}" role="button">{{ pages.developer.contribute.lifecycle }}</a>
-          </div>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3>{{ pages.developer.milestone.contribute }}</h3>
+        <p>{{ pages.developer.contribute.intro }}</p>
+        <div class="btn-group-vertical" role="group" aria-label="{{ pages.developer.contribute.label }}">
+          <a class="btn btn-primary" href="{{ links.developer.contribute.checklist }}" role="button">{{ pages.developer.contribute.checklist }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.contribute.lifecycle }}" role="button">{{ pages.developer.contribute.lifecycle }}</a>
         </div>
-        <div class="width-6-12 width-12-12-m">
-          <h3>{{ pages.developer.milestone.test }}</h3>
-          <p>{{ pages.developer.test.intro }}</p>
-          <div class="btn-group-vertical" role="group" aria-label="{{ pages.developer.test.label }}">
-            <a class="btn btn-primary" href="{{ links.developer.test.learn }}" role="button">{{ pages.developer.test.learn }}</a>
-            <a class="btn btn-primary" href="{{ links.developer.test.run }}" role="button">{{ pages.developer.test.run }}</a>
-            <a class="btn btn-primary" href="{{ links.developer.test.integration }}" role="button">{{ pages.developer.test.integration }}</a>
-            <a class="btn btn-primary" href="{{ links.developer.test.unit }}" role="button">{{ pages.developer.test.unit }}</a>
-          </div>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3>{{ pages.developer.milestone.test }}</h3>
+        <p>{{ pages.developer.test.intro }}</p>
+        <div class="btn-group-vertical" role="group"
+          aria-label="{{ pages.developer.test.label }}">
+          <a class="btn btn-primary" href="{{ links.developer.test.learn }}" role="button">{{ pages.developer.test.learn }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.test.run }}" role="button">{{ pages.developer.test.run }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.test.integration }}" role="button">{{ pages.developer.test.integration }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.test.unit }}" role="button">{{ pages.developer.test.unit }}</a>
         </div>
-        <div class="width-6-12 width-12-12-m">
-          <h3>{{ pages.developer.milestone.create_collection }}</h3>
-          <p>{{ pages.developer.create_collection.intro }}</p>
-          <div class="btn-group-vertical" role="group" aria-label="{{ pages.developer.create_collection.label }}">
-            <a class="btn btn-primary" href="{{ links.developer.create_collection.skeleton }}" role="button">{{ pages.developer.create_collection.skeleton }}</a>
-            <a class="btn btn-primary" href="{{ links.developer.create_collection.test }}" role="button">{{ pages.developer.create_collection.test }}</a>
-            <a class="btn btn-primary" href="{{ links.developer.create_collection.distribute }}" role="button">{{ pages.developer.create_collection.distribute }}</a>
-            <a class="btn btn-primary" href="{{ links.developer.create_collection.request_inclusion }}" role="button">{{ pages.developer.create_collection.request_inclusion }}</a>
-          </div>
+      </div>
+      <div class="width-6-12 width-12-12-m">
+        <h3>{{ pages.developer.milestone.create_collection }}</h3>
+        <p>{{ pages.developer.create_collection.intro }}</p>
+        <div class="btn-group-vertical" role="group"
+          aria-label="{{ pages.developer.create_collection.label }}">
+          <a class="btn btn-primary" href="{{ links.developer.create_collection.skeleton }}" role="button">{{ pages.developer.create_collection.skeleton }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.create_collection.test }}" role="button">{{ pages.developer.create_collection.test }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.create_collection.distribute }}" role="button">{{ pages.developer.create_collection.distribute }}</a>
+          <a class="btn btn-primary" href="{{ links.developer.create_collection.request_inclusion }}" role="button">{{ pages.developer.create_collection.request_inclusion }}</a>
         </div>
       </div>
     </div>
   </div>
+</div>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,10 +53,10 @@
       <div class="card-body">
         <h5>{{ pages.index.developer_heading }} <i class="fas fa-code"></i></h5>
         <p class="card-text">{{ pages.index.developer_body }}</p>
-        <div class="btn-group-vertical" role="group" aria-label="{{ pages.index.developer_actions.label }}">
-            <a class="btn btn-primary" href="{{ links.developer_actions.setup }}" role="button">{{ pages.index.developer_actions.setup }}</a>
-            <a class="btn btn-primary" href="{{ links.developer_actions.guidelines }}" role="button">{{ pages.index.developer_actions.guidelines }}</a>
-            <a class="btn btn-primary" href="{{ links.developer_actions.start }}" role="button">{{ pages.index.developer_actions.start }}</a>
+        <div class="btn-group-vertical" role="group" aria-label="{{ pages.developer.start.label }}">
+            <a class="btn btn-primary" href="{{ links.developer.start.setup }}" role="button">{{ pages.developer.start.setup }}</a>
+            <a class="btn btn-primary" href="{{ links.developer.start.conduct }}" role="button">{{ pages.developer.start.conduct }}</a>
+            <a class="btn btn-primary" href="{{ links.developer.start.code }}" role="button">{{ pages.developer.start.code }}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR collapses the developer actions for the index page and the developer page. Put all milestones and actions under the corresponding persona. Also cleans up developer.html formatting a little.