### PR TITLE
Horizontal scrolling on mobile

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -16,6 +16,7 @@ body {
   font-family: $redhat-text;
   position: relative;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 h1 {
   font-family: $redhat-display;

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -45,10 +45,6 @@ h6 {
   font-family: $redhat-display;
 }
 
-.container {
-  max-width: 75%;
-}
-
 .full-width-bg {
   margin: 0 -13rem;
   padding: 0 13rem;


### PR DESCRIPTION
Addresses #77 

@samccann I don't think this is the ideal solution although it seems to work ok from my testing. Maybe we can merge and try it out live and ping the reddit thread for thoughts?

Hiding overflow prevents horizontal scrolling on smaller screens but does truncate text in the intro paragraphs. The actual navigation seems fine to me. I can follow the links and access the pages. The scrolling issue only gets really bad on small displays, which won't be a great experience when you hit the doc pages.