### PR TITLE
Improve quicklinks

### DIFF
--- a/data/pages.yaml
+++ b/data/pages.yaml
@@ -228,7 +228,7 @@ buttons:
   learn_more: Learn more
   archive: Visit the archive
 feedback: <i class="fas fa-comments"></i> Got thoughts or feedback on the new documentation landing pages? We want to hear from you! <br /> Join us in the <a href="https://matrix.to/#/#docs:ansible.com" target="_blank">docs channel</a> on <a href="https://docs.ansible.com/ansible/latest/community/communication.html#ansible-community-on-matrix" target="_blank">Matrix</a> or open a <a href="https://github.com/ansible/docsite/issues" target="_blank">GitHub issue</a> in the docsite repository.
-take_me_back: Switch layout
+take_me_back: Restore the old layout
 # Translations
 translations:
   core_ja:

--- a/templates/developers.html
+++ b/templates/developers.html
@@ -2,16 +2,16 @@
 <div class="container">
   <div class="full-width-bg component">
     <div class="grid-wrapper">
-      <div class="width-3-12 width-12-12-m">
+      <!--<div class="width-3-12 width-12-12-m">
         <img class="page-logo" src="static/images/community_logo.svg">
-      </div>
-      <div class="width-7-12 width-12-12-m">
+      </div>-->
+      <div class="width-9-12 width-12-12-m">
         <h2 class="page-title">{{ pages.developer.title }}</h2>
         <p class="intropara">{{ pages.developer.intro }}</p>
         <p class="feedback">{{ pages.feedback }}</p>
       </div>
       <!-- Start quicklinks. -->
-      <div class="width-2-12 width-12-12-m">
+      <div class="width-3-12 width-12-12-m">
         <div class="quicklinks">
           <h2>{{ pages.quicklinks.heading }}</h2>
           <ul class="fa-ul">

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,16 +2,16 @@
 <div class="container">
   <div class="full-width-bg component">
     <div class="grid-wrapper">
-      <div class="width-3-12 width-12-12-m">
+      <!--<div class="width-3-12 width-12-12-m">
         <img class="page-logo" src="static/images/community_logo.svg">
-      </div>
-      <div class="width-7-12 width-12-12-m">
+      </div>-->
+      <div class="width-9-12 width-12-12-m">
         <h2 class="page-title">{{ pages.index.title }}</h2>
         <p class="intropara">{{ pages.index.intro }}</p>
         <p class="feedback">{{ pages.feedback }}</p>
       </div>
       <!-- Start quicklinks. -->
-      <div class="width-2-12 width-12-12-m">
+      <div class="width-3-12 width-12-12-m">
         <div class="quicklinks">
           <h2>{{ pages.quicklinks.heading }}</h2>
           <ul class="fa-ul">

--- a/templates/maintainers.html
+++ b/templates/maintainers.html
@@ -3,16 +3,16 @@
 <div class="container">
     <div class="full-width-bg component">
       <div class="grid-wrapper">
-      <div class="width-3-12 width-12-12-m">
-        <img class="page-logo" src="static/images/community_logo.svg">
-      </div>
-      <div class="width-7-12 width-12-12-m">
+        <!--<div class="width-3-12 width-12-12-m">
+          <img class="page-logo" src="static/images/community_logo.svg">
+        </div>-->
+      <div class="width-9-12 width-12-12-m">
         <h2 class="page-title">{{ pages.maintainer.title }}</h2>
         <p class="intropara">{{ pages.maintainer.intro }}</p>
         <p class="feedback">{{ pages.feedback }}</p>
       </div>
       <!-- Start quicklinks. -->
-      <div class="width-2-12 width-12-12-m">
+      <div class="width-3-12 width-12-12-m">
         <div class="quicklinks">
           <h2>{{ pages.quicklinks.heading }}</h2>
           <ul class="fa-ul">

--- a/templates/users.html
+++ b/templates/users.html
@@ -2,16 +2,16 @@
 <div class="container">
   <div class="full-width-bg component">
     <div class="grid-wrapper">
-      <div class="width-3-12 width-12-12-m">
+      <!--<div class="width-3-12 width-12-12-m">
         <img class="page-logo" src="static/images/community_logo.svg">
-      </div>
-      <div class="width-7-12 width-12-12-m">
+      </div>-->
+      <div class="width-9-12 width-12-12-m">
         <h2 class="page-title">{{ pages.user.title }}</h2>
         <p class="intropara">{{ pages.user.intro }}</p>
         <p class="feedback">{{ pages.feedback }}</p>
       </div>
       <!-- Start quicklinks. -->
-      <div class="width-2-12 width-12-12-m">
+      <div class="width-3-12 width-12-12-m">
         <div class="quicklinks">
           <h2>{{ pages.quicklinks.heading }}</h2>
           <ul class="fa-ul">


### PR DESCRIPTION
Fixes #98 

This PR removes the Ansible community logo from the index, user, developer, and maintainer pages so that the quicklinks section is more prominent and text is on a single line instead of wrapping, which doesn't look great.

The logo remains on the community, core, ecosystem pages.