### PR TITLE
Use output as the build path

### DIFF
--- a/.github/workflows/build-docsite.yaml
+++ b/.github/workflows/build-docsite.yaml
@@ -23,5 +23,5 @@ jobs:
     - name: Deploy to GH pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:
-        folder: build
+        folder: output
         branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # VScode stuff
 .vscode/
+
+# Generated HTML
+output/

--- a/build.py
+++ b/build.py
@@ -18,18 +18,19 @@ def data():
         "controller_translations": load(open("data/controller_translations.yaml"), Loader=Loader)
     }
 
-buildpath = Path('build')
+buildpath = Path('output')
+
 if buildpath.exists() and buildpath.is_dir():
-    shutil.rmtree("build")
+    shutil.rmtree(buildpath)
 
 if __name__ == "__main__":
 
     site = Site.make_site()
-    site.outpath="build"
+    site.outpath=buildpath
     site.contexts=[(".*.html", data)]
     # disable automatic reloading
     site.render(use_reloader=False)
 
 
-    shutil.copytree('static', 'build/static')
-    sass.compile(dirname=('sass', 'build/static/css'))
+    shutil.copytree('static', buildpath / 'static')
+    sass.compile(dirname=('sass', buildpath / 'static/css'))


### PR DESCRIPTION
This PR changes the way the docsite is built to put the generated HTML in a build path named "output". This matches the commonly used folder name for other site generators.